### PR TITLE
Update regex to account for :+1: and :-1:

### DIFF
--- a/emojify
+++ b/emojify
@@ -22,7 +22,7 @@
 
 
 # Regex for emoji names like :sparkling_heart:
-regex=':([A-Za-z0-9_])+:'
+regex=':([A-Za-z0-9_+-])+:'
 
 # Gets emoji from 'hash'
 # Returns raw emoji character or word


### PR DESCRIPTION
👍 (the `:+1:` form) is one of my most used emojis on GitHub as well as related sites that support the same set of emojis (and it's certainly the first one on GitHub's emoji completion list). Therefore, I wasn't heartened to have my first session with `emojify` be like

```
> emojify :+1:
:+1:
```

...

And it's a trivial fix: just add `+` and `-` to the character class. I have double checked that after adding these two, no more character is left out. (In fact, `A-Z` should not be included, but that's not a big deal.)