### PR TITLE
Fix "tr: Illegal byte sequence" on Mac OS X

### DIFF
--- a/emojify
+++ b/emojify
@@ -65,7 +65,7 @@ emojify () {
     local emojified=$line
   fi
 
-  echo $emojified | tr -d '\b'
+  echo $emojified | LC_CTYPE=C tr -d '\b'
 }
 
 # Emoji in something like a hash or associative array


### PR DESCRIPTION
That rarely happens because of difference between `tr` command on Linux and Mac OS X.

It'll be probably fixed this patch. Moreover, its seemingly indifferent to Linux.

Thanks.
