### PR TITLE
use -r flag to read [back]slashes

### DIFF
--- a/emojify
+++ b/emojify
@@ -1849,7 +1849,7 @@ to_emoji () {
 # Function to parse a line, split it into an array of words and then emojify
 # each word.
 parse_line () {
-    IFS=' '; read -a words_arr <<< $*
+    IFS=' '; read -ra words_arr <<< $*
     out=()
     for word in "${words_arr[@]}"; do
         out+=("$(to_emoji "$word")")


### PR DESCRIPTION
Input
```
echo '\' | emojify
```

Master output
```
```

Branch output
```
\
```

Noticed when piping git log results through emojify.  Running `git log --oneline --color --graph | emojify | less -r` against this repo produced
<img width="677" alt="master" src="https://user-images.githubusercontent.com/1791503/28204888-7b7a2bf4-681b-11e7-9cbf-6818b89da81c.png">

After adding the `-r` flag, it produces the expected
<img width="691" alt="branch" src="https://user-images.githubusercontent.com/1791503/28204916-90df46b4-681b-11e7-9a71-f8bcafc1848d.png">


