### PR TITLE
Add Arch Linux PKGBUILD

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If you're on OS X, emojify is also on [Homebrew](http://brew.sh/):
 ```sh
 $ brew install emojify
 ```
+For Arch Linux users, a PKGBUILD is available in the [AUR](https://aur.archlinux.org/packages/emojify/):
+```sh
+$ pacaur -S emojify
+```
 
 Usage
 -----


### PR DESCRIPTION
I added a PKGBUILD for users of Arch Linux (and Antergos/Manjaro), so emojify can be handled by its native package manager.